### PR TITLE
Corrected counting of cnots in BAA algorithm

### DIFF
--- a/qclib/state_preparation/util/baa.py
+++ b/qclib/state_preparation/util/baa.py
@@ -261,19 +261,23 @@ def _count_saved_cnots(entangled_vector, subsystem1_vector, subsystem2_vector):
     return cnots_originally - cnots_phase_3 - cnots_phase_4
 
 def _cnots(n_qubits):
-    if n_qubits == 1:
-        return 0
-    if n_qubits == 2:
-        return 2
-    if n_qubits == 3:
-        return 4
+    if n_qubits < 4:
+        cnot_counting = [0, 2, 4]
+        return cnot_counting[n_qubits-1]
+
+    # The expressions below are valid for k >= 2 (n_qubits >= 4).
+    # These are the expressions for the unitary decomposition QSD l=2 without
+    # the optimizations. With the optimizations, they need to be replaced.
+    # In some cases, the actual CNOT count of the Schmidt state preparation
+    # may be a bit larger. It happens because we do not yet have an efficient
+    # implementation for (n-1)-to-n isometries (like Cosine-Sine decomposition).
     if n_qubits % 2 == 0:
         k = n_qubits/2
-        return int(2 ** k - k - 1 + k + 23/24*2**(2*k) - 3/2 * 2**(k+1) + 8/3)
+        return int(2 ** k - 1 + 9/8*2**(2*k) - 3/2 * 2**(k+1))
 
     k = (n_qubits-1)/2
-    return int(2 ** k - k - 1 + k + 23/48*2**(2*k) - 3/2 * 2**(k) + 4/3 +
-                                    23/48*2**(2*k + 2) - 3/2 * 2**(k + 1) + 4/3)
+    return int(2 ** k - 1 + 9/16*2**(2*k) - 3/2 * 2**(k) +
+                            9/16*2**(2*k + 2) - 3/2 * 2**(k + 1))
 
 def _to_qubits(n_state_vector):
     return int(np.ceil(np.log2(n_state_vector)))

--- a/qclib/state_preparation/util/baa.py
+++ b/qclib/state_preparation/util/baa.py
@@ -253,10 +253,10 @@ def _separation_matrix(vector, subsystem2):
 
     return sep_matrix
 
-def _count_saved_cnots(state_vector, entangled_vector, disentangled_vector):
-    cnots_phase_3 = _cnots(_to_qubits(entangled_vector.shape[0]))
-    cnots_phase_4 = _cnots(_to_qubits(disentangled_vector.shape[0]))
-    cnots_originally = _cnots(_to_qubits(state_vector.shape[0]))
+def _count_saved_cnots(entangled_vector, subsystem1_vector, subsystem2_vector):
+    cnots_phase_3 = _cnots(_to_qubits(subsystem1_vector.shape[0]))
+    cnots_phase_4 = _cnots(_to_qubits(subsystem2_vector.shape[0]))
+    cnots_originally = _cnots(_to_qubits(entangled_vector.shape[0]))
 
     return cnots_originally - cnots_phase_3 - cnots_phase_4
 

--- a/test/test_baa_schmidt.py
+++ b/test/test_baa_schmidt.py
@@ -125,6 +125,7 @@ class TestBaaSchmidt(TestCase):
         self.assertTrue(np.allclose(state_vector, state))
 
     def test_initialize_ame(self):
+        """ Test initialization of a absolutely maximally entangled state"""
         state_vector = [1, 1, 1, 1,1,-1,-1, 1, 1,-1,-1, 1, 1, 1,1,1,
                         1, 1,-1,-1,1,-1, 1,-1,-1, 1,-1, 1,-1,-1,1,1]
         state_vector = state_vector / np.linalg.norm(state_vector)

--- a/test/test_schmidt.py
+++ b/test/test_schmidt.py
@@ -76,6 +76,7 @@ class TestSchmidt(TestCase):
         self.assertTrue(np.allclose(state_vector, state))
 
     def test_initialize_ame(self):
+        """ Test initialization of a absolutely maximally entangled state"""
         state_vector = [1, 1, 1, 1,1,-1,-1, 1, 1,-1,-1, 1, 1, 1,1,1,
                         1, 1,-1,-1,1,-1, 1,-1,-1, 1,-1, 1,-1,-1,1,1]
         state_vector = state_vector / np.linalg.norm(state_vector)

--- a/test/test_unitary.py
+++ b/test/test_unitary.py
@@ -84,37 +84,3 @@ class TestUnitary(TestCase):
         calc2 = v_gate @ np.diag(diag).conj().T @ w_gate
         self.assertTrue(np.allclose(calc1, gate1))
         self.assertTrue(np.allclose(calc2, gate2))
-
-    def test_compute_gates_fixed(self):
-        """ test auxiliar funciont compute gates"""
-        gate1 = np.array(
-                [[ 1.39499204e-01-1.02062065e-01j, -3.73248642e-01-6.00570938e-01j,
-                   5.83554297e-01-1.84683236e-01j, -2.69576508e-01+1.51024165e-01j],
-                 [-4.71845544e-01-6.91006095e-01j, -7.85046229e-17+0.00000000e+00j,
-                   2.78615481e-01+1.87070569e-01j,  4.00199035e-01-1.64593766e-01j],
-                 [ 7.04556392e-02-4.84927805e-01j,  0.00000000e+00+9.81307787e-18j,
-                  -3.29381826e-01-1.72042433e-01j, -6.36139910e-01-4.65957139e-01j],
-                 [-1.02062065e-01-1.39499204e-01j,  6.00570938e-01-3.73248642e-01j,
-                  -1.84683236e-01-5.83554297e-01j,  1.51024165e-01+2.69576508e-01j]])
-        gate2 = np.array(
-                [[ 1.72752243e-01-5.77541244e-03j,  2.97965199e-02-7.06478710e-01j,
-                   5.86222022e-01+1.76031973e-01j, -3.07814277e-01-2.70215300e-02j],
-                 [-8.22782535e-01+1.52172736e-01j,  4.11897902e-17+7.20821328e-17j,
-                   2.83747390e-01-1.79190967e-01j,  1.12670242e-02-4.32577657e-01j],
-                 [-4.15037537e-01-2.60504925e-01j, -1.02974475e-17+4.11897902e-17j,
-                  -2.90528108e-01+2.31698952e-01j, -6.83375688e-01+3.93430693e-01j],
-                 [-5.77541244e-03-1.72752243e-01j,  7.06478710e-01+2.97965199e-02j,
-                   1.76031973e-01-5.86222022e-01j, -2.70215300e-02+3.07814277e-01j]])
-
-        # Let's find the closest unitary matrices to gate1 and gate2.
-        def closest_unitary(matrix):
-            svd_u,_,svd_v = np.linalg.svd(matrix)
-            return svd_u.dot(svd_v)
-        gate1 = closest_unitary(gate1)
-        gate2 = closest_unitary(gate2)
-
-        diag, v_gate, w_gate = _compute_gates(gate1, gate2)
-        calc1 = v_gate @ np.diag(diag) @ w_gate
-        calc2 = v_gate @ np.diag(diag).conj().T @ w_gate
-        self.assertTrue(np.allclose(calc1, gate1))
-        self.assertTrue(np.allclose(calc2, gate2))


### PR DESCRIPTION
* These are the expressions for the unitary decomposition QSD l=2 without the optimizations. With the optimizations, they need to be replaced.

* In some cases, the actual CNOT count of the Schmidt state preparation may be a bit larger. It happens because we do not yet have an efficient implementation for (n-1)-to-n isometries (like Cosine-Sine decomposition).