### PR TITLE
Feature/small additions

### DIFF
--- a/qclib/entanglement.py
+++ b/qclib/entanglement.py
@@ -1,0 +1,97 @@
+# Copyright 2021 qclib project.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+
+
+def _get_iota(j: int, n: int, b: int, basis_state: int):
+    assert b in [0, 1]
+    full_mask = 2**n - 1
+
+    mask_j = 1 << j
+    value = (mask_j & basis_state) >> j
+
+    low_mask = full_mask >> (n - j)
+    high_mask = full_mask & (full_mask << (j + 1))
+    new_basis_state = ((basis_state & high_mask) >> 1) + (basis_state & low_mask)
+
+    return value == b, new_basis_state
+
+
+def generalized_cross_product(u: np.ndarray, v: np.ndarray):
+    entries = []
+    for j in range(u.shape[0]):
+        for i in range(j):
+            entry = np.abs(u[i] * v[j] - u[j] * v[i])**2
+            entries.append(entry)
+    return np.sum(entries)
+
+
+def meyer_wallach_entanglement(vector: np.ndarray):
+    num_qb = _to_qubits(vector.shape[0])
+    meyer_wallach_entry = np.zeros(shape=(num_qb, 1))
+    for j in range(num_qb):
+        psi_0 = np.zeros(shape=(vector.shape[0]//2, 1), dtype=complex)
+        psi_1 = np.zeros(shape=(vector.shape[0]//2, 1), dtype=complex)
+        for basis_state, entry in enumerate(vector):
+            delta_0, new_basis_state_0 = _get_iota(j, num_qb, 0, basis_state)
+            delta_1, new_basis_state_1 = _get_iota(j, num_qb, 1, basis_state)
+
+            if delta_0:
+                psi_0[new_basis_state_0] = entry
+            if delta_1:
+                psi_1[new_basis_state_1] = entry
+
+        entry = generalized_cross_product(psi_0, psi_1)
+        meyer_wallach_entry[j] = entry
+
+    return np.sum(meyer_wallach_entry) * (4/num_qb)
+
+
+def geometric_entanglement(state_vector, return_product_state=False):
+    import importlib.util
+    tensorly_loader = importlib.util.find_spec('tensorly')
+    if tensorly_loader is None:
+        raise ImportError(
+            "To calculate the geometric entanglement we use Tucker decomposition"
+            " and use tensorly for that. Please install it, e.g., "
+            "`pip install tensortly`."
+        )
+
+    import tensorly as tl
+    from tensorly.tucker_tensor import TuckerTensor
+    from tensorly.decomposition import tucker
+
+    shape = tuple([2] * _to_qubits(state_vector.shape[0]))
+    rank = [1] * _to_qubits(state_vector.shape[0])
+    tensor = tl.tensor(state_vector).reshape(shape)
+    results = {}
+    # The Tucker decomposition is actually a randomized algorithm.
+    # We take three shots and take the min of it.
+    for _ in range(3):
+        decomp_tensor: TuckerTensor = tucker(
+            tensor, rank=rank, verbose=False, svd='numpy_svd', init='random'
+        )
+        fidelity_loss = 1 - np.linalg.norm(decomp_tensor.core) ** 2
+        results[fidelity_loss] = decomp_tensor
+
+    min_fidelity_loss = min(results)
+
+    if return_product_state:
+        return min_fidelity_loss, decomp_tensor.factors
+    else:
+        return min_fidelity_loss
+
+
+def _to_qubits(n_state_vector):
+    return int(np.ceil(np.log2(n_state_vector))) if n_state_vector > 0 else 0

--- a/qclib/state_preparation/baa_schmidt.py
+++ b/qclib/state_preparation/baa_schmidt.py
@@ -24,7 +24,8 @@ from qclib.state_preparation.util.baa import adaptive_approximation
 
 def initialize(state_vector, max_fidelity_loss=0.0,
                         isometry_scheme='ccd', unitary_scheme='qsd',
-                        strategy='greedy', max_combination_size=0, use_low_rank=False):
+                        strategy='greedy', max_combination_size=0,
+                        use_low_rank=False, return_node=False):
     """
     State preparation using the bounded approximation algorithm via Schmidt
     decomposition arXiv:1003.5760
@@ -73,10 +74,16 @@ def initialize(state_vector, max_fidelity_loss=0.0,
             tuning for high-entanglement states and is slower.
             The default value is False.
 
+    return_node: bool
+            If set to true, returns also the best node for the
+            decomposition/approximation
+
     Returns
     -------
-    circuit: QuantumCircuit
-        QuantumCircuit to initialize the state.
+    circuit: QuantumCircuit or Tuple[QuantumCircuit, Node]
+        QuantumCircuit to initialize the state or if return_node==True, returns
+        a tuple with the QuantumCircuit and the best node for
+        decomposition/approximation.
     """
 
     if max_fidelity_loss < 0 or max_fidelity_loss > 1:
@@ -98,5 +105,8 @@ def initialize(state_vector, max_fidelity_loss=0.0,
         qc_vec = schmidt.initialize(vec, isometry_scheme=isometry_scheme,
                                             unitary_scheme=unitary_scheme)
         circuit.compose(qc_vec, node.qubits[i][::-1], inplace=True) # qiskit little-endian.
-
-    return circuit.reverse_bits() # qiskit little-endian.
+    qiskit_circuit = circuit.reverse_bits() # qiskit little-endian.
+    if return_node:
+        return qiskit_circuit, node
+    else:
+        return qiskit_circuit

--- a/qclib/state_preparation/util/baa.py
+++ b/qclib/state_preparation/util/baa.py
@@ -114,6 +114,14 @@ class Node:
 
     nodes: List['Node']
 
+    def num_qubits(self):
+        return len(set([e for qb_list in self.qubits for e in qb_list]))
+
+    def state_vector(self):
+        import tensorly.tenalg
+        state = tensorly.tenalg.kronecker(self.vectors)
+        return state
+
     def __str__(self):
         str_vectors = '\n'.join([str(np.around(i,2)) for i in self.vectors])
         str_qubits = ' '.join([str(i) for i in self.qubits])

--- a/qclib/state_preparation/util/tree_walk.py
+++ b/qclib/state_preparation/util/tree_walk.py
@@ -46,8 +46,8 @@ def top_down(angle_tree, circuit, start_level, control_nodes=None, target_nodes=
             else:
                 target_nodes = children(target_nodes)        # all the nodes in the current level
 
-            angles_y = [node.angle_y for node in target_nodes]
-            angles_z = [node.angle_z for node in target_nodes]
+            angles_y = [float(node.angle_y) for node in target_nodes]
+            angles_z = [float(node.angle_z) for node in target_nodes]
             target_qubit = target_nodes[0].qubit
             control_qubits = [node.qubit for node in control_nodes]
             circuit.ucry(angles_y, control_qubits[::-1], target_qubit)     # qiskit reverse

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ qiskit
 graphviz
 deprecation
 numpy
+tensorly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 qiskit
 graphviz
 deprecation
+numpy


### PR DESCRIPTION

### Small Adjustments to the latest big PR and code change.

This PR changes a couple of topics:

1. Although NumPy is implicitly installed through qiskit (e.g.), I think making it explicit is a good practice.
2. A module / file for calculating entanglement measures is useful and should be included.
3. For several good reasons, being able to return the best node is good to include as an option.
4. (BUG-FIX) Sometimes the angles are given as 1d single entry NumPy arrays. This breaks the code. The suggested solution catches this while not introducing any ambiguity. To avoid this would be better, but it seems to be non-trivial.
5. Getting the number of qubits in total and the reconstructed state vector are very useful additions. Using tensorly here introduces another dependency, but with the advantage of having a tested and battle-proven routine doing the job.

Please check out the changes and decide if you can proceed @israelferrazaraujo. Thanks a lot!

NB: I would like to add [tensorly](https://pypi.org/project/tensorly/) as a dependency as I think it will be used more often. I will gladly explain why I think that we want to continue with it. We don't necessarily need to include it in this PR, but I would like to start the discussion here.