### PR TITLE
Bugfix/geo entanglement

### DIFF
--- a/qclib/entanglement.py
+++ b/qclib/entanglement.py
@@ -125,8 +125,8 @@ def geometric_entanglement(state_vector: np.ndarray, return_product_state=False
     tensor = tl.tensor(state_vector).reshape(shape)
     results = {}
     # The Tucker decomposition is actually a randomized algorithm.
-    # We take three shots and take the min of it.
-    for _ in range(3):
+    # We take four shots and take the min of it.
+    for _ in range(4):
         decomp_tensor: TuckerTensor = tucker(
             tensor, rank=rank, verbose=False, svd='numpy_svd', init='random'
         )

--- a/qclib/entanglement.py
+++ b/qclib/entanglement.py
@@ -136,7 +136,7 @@ def geometric_entanglement(state_vector: np.ndarray, return_product_state=False
     min_fidelity_loss = min(results)
 
     if return_product_state:
-        return min_fidelity_loss, decomp_tensor.factors
+        return min_fidelity_loss, [f.flatten() for f in results[min_fidelity_loss].factors]
 
     return min_fidelity_loss
 


### PR DESCRIPTION
Fixing the bug that I found: use the decomposition of minimum and flatten to 1d arrays. The current solution uses the last decomposition, which does not fit with the best found overlap! 

Also, I saw that the approximations should have another shot to increase the chance.

You can come up with a better solution here!