### PR TITLE
Fixing bug concerning Value error on schmidt composition

### DIFF
--- a/qclib/entanglement.py
+++ b/qclib/entanglement.py
@@ -218,7 +218,7 @@ def schmidt_composition(svd_u, svd_v, singular_values, partition):
 
     n_qubits = _to_qubits(svd_u.shape[0]) + _to_qubits(svd_v.shape[1])
 
-    sep_matrix = (svd_u * singular_values) @ svd_v
+    sep_matrix = (svd_u @ singular_values) @ svd_v
 
     state_vector = _undo_separation_matrix(n_qubits, sep_matrix, partition)
 


### PR DESCRIPTION
**The problem:**
When trying to perform schmidt composition implemented on qclib it raises a value error as folows:
`ValueError: operands could not be broadcast together with shapes (x,x) (x,y)`

For x and y being any integer. 

**How to replicate it:**
One needs to use the numpy library and try to use the elements returned by the schmidt decomposition:
```python
state = np.random.rand(2**8)
state = state / np.linalg.norm(state)
u, s, vh = schmidt_decomposition(state, [0, 1, 2])
s = s / np.linalg.norm(s)
diag = np.diag(s)
zeros = np.zeros((24, 8))
diagonal_matrix = np.vstack([diag, zeros])
state_rebuilt = schmidt_decomposition(u, vh, diagonal_matrix, [0, 1, 2])
```

