### PR TITLE
mcx with ancilla and optimizations

### DIFF
--- a/qclib/gates/mcx_gate.py
+++ b/qclib/gates/mcx_gate.py
@@ -1,0 +1,178 @@
+# Copyright 2021 qclib project.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+linear-depth n-qubit controlled X with ancilla
+"""
+
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import C3XGate, C4XGate
+
+
+def mcx_v_chain_dirty(
+    self,
+    control_qubits,
+    target_qubit,
+    ancilla_qubits,
+    ctrl_state=None,
+    relative_phase=False,
+    action_only=False
+):
+    """
+        In-place application of k-controlled X gate with k - 2 dirty ancilla qubits.
+        This decomposition uses the optimization shown in Lemma 8 of
+        https://arxiv.org/abs/1501.06911), which contains at most 8k - 6 `cx`.
+
+        Parameters
+        ----------
+        circuit : quantum circuit where the k-controlled X will be applied
+        control_qubits : k control qubits
+        ancilla_qubits : at least k - 2 dirty ancilla qubits
+        target_qubit : target qubit of the operation
+    """
+
+    num_ctrl = len(control_qubits)
+    num_ancilla = num_ctrl - 2
+    targets = [target_qubit] + ancilla_qubits[:num_ancilla][::-1]
+
+    if ctrl_state is not None:
+        for i, ctrl in enumerate(ctrl_state[::-1]):
+            if ctrl == '0':
+                self.x(control_qubits[i])
+
+    if num_ctrl < 3:
+        self.mcx(
+            control_qubits=control_qubits,
+            target_qubit=target_qubit,
+            mode="noancilla"
+        )
+    elif num_ctrl == 3:
+        self.append(C3XGate(), [*control_qubits[:], target_qubit], [])
+    else:
+        for j in range(2):
+            for i, _ in enumerate(control_qubits):      # action part
+                if i < num_ctrl - 2:
+                    if targets[i] != target_qubit or relative_phase:  # gate cancelling
+                        theta = np.pi / 4.
+
+                        # cancel rightmost gates of action part with leftmost gates of reset part
+                        if (relative_phase and targets[i] == target_qubit and j == 1):
+                            self.cx(ancilla_qubits[num_ancilla - i - 1], targets[i])
+                            self.u(theta=theta, phi=0., lam=0., qubit=targets[i])
+                            self.cx(control_qubits[num_ctrl - i - 1], targets[i])
+                            self.u(theta=theta, phi=0., lam=0., qubit=targets[i])
+                        else:
+                            self.u(theta=-theta, phi=0., lam=0., qubit=targets[i])
+                            self.cx(control_qubits[num_ctrl - i - 1], targets[i])
+                            self.u(theta=-theta, phi=0., lam=0., qubit=targets[i])
+                            self.cx(ancilla_qubits[num_ancilla - i - 1], targets[i])
+
+                    else:
+                        self.ccx(
+                            control_qubit1=control_qubits[num_ctrl - i - 1],
+                            control_qubit2=ancilla_qubits[num_ancilla - i - 1],
+                            target_qubit=targets[i]
+                        )
+                else:
+                    theta = np.pi / 4.
+
+                    self.u(theta=-theta, phi=0., lam=0., qubit=targets[i])
+                    self.cx(control_qubits[num_ctrl - i - 2], targets[i])
+                    self.u(theta=-theta, phi=0., lam=0., qubit=targets[i])
+                    self.cx(control_qubits[num_ctrl - i - 1], targets[i])
+                    self.u(theta=theta, phi=0., lam=0., qubit=targets[i])
+                    self.cx(control_qubits[num_ctrl - i - 2], targets[i])
+                    self.u(theta=theta, phi=0., lam=0., qubit=targets[i])
+
+                    break
+
+            for i, _ in enumerate(ancilla_qubits[1:]):      # reset part
+                theta = np.pi / 4.
+
+                self.cx(ancilla_qubits[i], ancilla_qubits[i + 1])
+                self.u(theta=theta, phi=0., lam=0., qubit=ancilla_qubits[i + 1])
+                self.cx(control_qubits[2 + i], ancilla_qubits[i + 1])
+                self.u(theta=theta, phi=0., lam=0., qubit=ancilla_qubits[i + 1])
+
+            if action_only:
+                break
+
+    if ctrl_state is not None:
+        for i, ctrl in enumerate(ctrl_state[::-1]):
+            if ctrl == '0':
+                self.x(control_qubits[i])
+
+
+QuantumCircuit.mcx_v_chain_dirty = mcx_v_chain_dirty
+
+
+def linear_mcx(
+    self,
+    control_qubits,
+    target_qubit,
+    ancilla_qubits
+):
+    """
+        Linear-depth implementation of multicontrolled X with one dirty ancilla
+        following the decomposition first shown in
+            https://link.aps.org/doi/10.1103/PhysRevA.52.3457
+    """
+
+    if self.num_qubits < 5:
+        self.mcx(
+            control_qubits=control_qubits,
+            target_qubit=target_qubit,
+            mode="noancilla"
+        )
+    elif self.num_qubits == 5:
+        self.append(C3XGate(), [*control_qubits[:], target_qubit], [])
+    elif self.num_qubits == 6:
+        self.append(C4XGate(), [*control_qubits[:], target_qubit], [])
+    elif self.num_qubits == 7:
+        self.append(C3XGate(), [*control_qubits[:3], ancilla_qubits], [])
+        self.append(C3XGate(), [*control_qubits[3:], ancilla_qubits, target_qubit], [])
+        self.append(C3XGate(), [*control_qubits[:3], ancilla_qubits], [])
+        self.append(C3XGate(), [*control_qubits[3:], ancilla_qubits, target_qubit], [])
+    else:
+        num_ctrl = len(control_qubits)
+
+        # split controls to halve the number of qubits used for each mcx
+        k_1 = int(np.ceil((num_ctrl + 1.) / 2.))
+        k_2 = int(np.floor((num_ctrl + 1.) / 2.))
+
+        self.mcx_v_chain_dirty(
+            control_qubits=control_qubits[:k_1],
+            target_qubit=ancilla_qubits,
+            ancilla_qubits=control_qubits[k_1:k_1 + k_1 - 2]
+        )
+        self.mcx_v_chain_dirty(
+            control_qubits=[*control_qubits[k_1:], ancilla_qubits],
+            target_qubit=target_qubit,
+            ancilla_qubits=control_qubits[k_1 - k_2 + 2:k_1]
+        )
+        self.mcx_v_chain_dirty(
+            control_qubits=control_qubits[:k_1],
+            target_qubit=ancilla_qubits,
+            ancilla_qubits=control_qubits[k_1:k_1 + k_1 - 2]
+        )
+        self.mcx_v_chain_dirty(
+            control_qubits=[*control_qubits[k_1:], ancilla_qubits],
+            target_qubit=target_qubit,
+            ancilla_qubits=control_qubits[k_1 - k_2 + 2:k_1]
+        )
+
+
+QuantumCircuit.linear_mcx = linear_mcx

--- a/test/test_mcx_gate.py
+++ b/test/test_mcx_gate.py
@@ -1,0 +1,148 @@
+# Copyright 2021 qclib project.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Test linear mcx with ancilla """
+
+from unittest import TestCase
+
+import numpy as np
+from qiskit import QuantumCircuit, QuantumRegister, transpile
+from qiskit.quantum_info import Operator
+from qclib.gates.mcx_gate import mcx_v_chain_dirty
+from qclib.gates.mcx_gate import linear_mcx
+
+
+class TestLinearMCX(TestCase):
+    """ Testing qclib.gates.mcx_gate """
+
+    QuantumCircuit.mcx_v_chain_dirty = mcx_v_chain_dirty
+    QuantumCircuit.linear_mcx = linear_mcx
+
+
+    def test_mcx_v_chain_dirty(self):
+        """ Test if mcx_v_chain_dirty is correct """
+
+        for num_controls in range(6, 8):
+            num_ancilla = num_controls - 2
+            control_qubits = QuantumRegister(num_controls)
+            ancilla_qubits = QuantumRegister(num_ancilla)
+            target_qubit = QuantumRegister(1)
+
+            mcx_v_chain = QuantumCircuit(control_qubits, ancilla_qubits, target_qubit)
+
+            mcx_v_chain.mcx_v_chain_dirty(
+                control_qubits=control_qubits,
+                target_qubit=target_qubit,
+                ancilla_qubits=ancilla_qubits
+            )
+
+            mcx_v_chain_qiskit = QuantumCircuit(control_qubits, ancilla_qubits, target_qubit)
+
+            mcx_v_chain_qiskit.mcx(
+                control_qubits=control_qubits,
+                target_qubit=target_qubit,
+                ancilla_qubits=ancilla_qubits,
+                mode="v-chain-dirty"
+            )
+
+            mcx_v_chain_op = Operator(mcx_v_chain).data
+            mcx_v_chain_qiskit_op = Operator(mcx_v_chain_qiskit).data
+
+            self.assertTrue(np.allclose(mcx_v_chain_op, mcx_v_chain_qiskit_op))
+
+
+    def test_mcx_v_chain_dirty_depth(self):
+        """ Test mcx_v_chain_dirty depth"""
+
+        for num_controls in range(30, 31):
+            num_ancilla = num_controls - 2
+            control_qubits = QuantumRegister(num_controls)
+            ancilla_qubits = QuantumRegister(num_ancilla)
+            target_qubit = QuantumRegister(1)
+
+            mcx_v_chain = QuantumCircuit(control_qubits, ancilla_qubits, target_qubit)
+
+            mcx_v_chain.mcx_v_chain_dirty(
+                control_qubits=control_qubits,
+                target_qubit=target_qubit,
+                ancilla_qubits=ancilla_qubits
+            )
+
+            mcx_v_chain_qiskit = QuantumCircuit(control_qubits, ancilla_qubits, target_qubit)
+
+            mcx_v_chain_qiskit.mcx(
+                control_qubits=control_qubits,
+                target_qubit=target_qubit,
+                ancilla_qubits=ancilla_qubits,
+                mode="v-chain-dirty"
+            )
+
+            tr_mcx_v_chain = transpile(mcx_v_chain, basis_gates=['u', 'cx'])
+            tr_mcx_v_chain_qiskit = transpile(mcx_v_chain_qiskit, basis_gates=['u', 'cx'])
+
+            self.assertLess(tr_mcx_v_chain.depth(), tr_mcx_v_chain_qiskit.depth())
+
+
+    def test_linear_mcx(self):
+        """ Test if linear_mcx is correct """
+
+        for num_qubits in range(6, 8):
+            mcx_dirty_ancilla = QuantumCircuit(num_qubits)
+
+            mcx_dirty_ancilla.linear_mcx(
+                control_qubits=list(range(num_qubits - 2)),
+                target_qubit=num_qubits - 2,
+                ancilla_qubits=num_qubits - 1
+            )
+
+            mcx_qiskit = QuantumCircuit(num_qubits)
+
+            mcx_qiskit.mcx(
+                control_qubits=list(range(num_qubits - 2)),
+                target_qubit=num_qubits - 2,
+                ancilla_qubits=num_qubits - 1,
+                mode="recursion"
+            )
+
+            mcx_dirty_ancilla_op = Operator(mcx_dirty_ancilla).data
+            mcx_qiskit_op = Operator(mcx_qiskit).data
+
+            self.assertTrue(np.allclose(mcx_dirty_ancilla_op, mcx_qiskit_op))
+
+
+    def test_linear_mcx_depth(self):
+        """ Test linear_mcx depth"""
+
+        for num_qubits in range(30, 31):
+            mcx_dirty_ancilla = QuantumCircuit(num_qubits)
+
+            mcx_dirty_ancilla.linear_mcx(
+                control_qubits=list(range(num_qubits - 2)),
+                target_qubit=num_qubits - 2,
+                ancilla_qubits=num_qubits - 1
+            )
+
+            mcx_qiskit = QuantumCircuit(num_qubits)
+
+            mcx_qiskit.mcx(
+                control_qubits=list(range(num_qubits - 2)),
+                target_qubit=num_qubits - 2,
+                ancilla_qubits=num_qubits - 1,
+                mode="recursion"
+            )
+
+            tr_mcx_dirty_ancilla = transpile(mcx_dirty_ancilla, basis_gates=['u', 'cx'])
+            tr_mcx_qiskit = transpile(mcx_qiskit, basis_gates=['u', 'cx'])
+
+            self.assertLess(tr_mcx_dirty_ancilla.depth(), tr_mcx_qiskit.depth())


### PR DESCRIPTION
This contains both Lemmas 8 and 9 as seen in Iten et al. (2016).

The v-chain mcx has the expected CNOT count of $8k-6$ for $k$ controls.
![pr_mcx_v_chain_graph](https://user-images.githubusercontent.com/26910380/207093744-6fe21802-ca0d-47b1-b195-7f6af95cde42.png)


The mcx with one ancilla has the expected CNOT count of $16n-40$ for $n$ qubits.
![pr_mcx_ancilla_graph](https://user-images.githubusercontent.com/26910380/207093841-8a395f76-c267-4aa3-953f-23ed0e0ba31a.png)