### PR TITLE
ctrl_state bug

### DIFF
--- a/qclib/gates/mcg.py
+++ b/qclib/gates/mcg.py
@@ -303,9 +303,6 @@ def quadratic_depth_mcg_u2(
 
     num_ctrl = len(controls)
 
-    if ctrl_state is None: 
-        ctrl_state = '1' * num_ctrl
-
     if num_ctrl == 2:
         u_gate = QuantumCircuit(1)
         u_gate.unitary(u_2, 0)
@@ -317,6 +314,9 @@ def quadratic_depth_mcg_u2(
             [*controls, target]
         )
     else:
+        if ctrl_state is None:
+            ctrl_state = '1' * num_ctrl
+
         # Notice that `ctrl_state`` is reversed with respect to `controls``.
         v_op = sqrtm(u_2)
 

--- a/qclib/gates/mcg.py
+++ b/qclib/gates/mcg.py
@@ -303,6 +303,9 @@ def quadratic_depth_mcg_u2(
 
     num_ctrl = len(controls)
 
+    if ctrl_state is None: 
+        ctrl_state = '1' * num_ctrl
+
     if num_ctrl == 2:
         u_gate = QuantumCircuit(1)
         u_gate.unitary(u_2, 0)


### PR DESCRIPTION
When using quadratic_depth_mcg_u2 and setting ctrl_state as None the method would raise an error saying that a None object is non subscriptable. It was fixed by assuming that the ctrl_state is a sequence of ones eg.: '111111...'