### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/qclib/ansatzes/qcnn.py
+++ b/qclib/ansatzes/qcnn.py
@@ -18,6 +18,8 @@
     https://link.springer.com/article/10.1007/s42484-021-00061-x
 """
 
+from __future__ import annotations
+
 from typing import Sequence, Mapping
 
 import numpy


### PR DESCRIPTION
Adds operand type support to Python 3.8.