### PR TITLE
[BUG FIX] Removing residual code from old version

### DIFF
--- a/qclib/state_preparation/merge.py
+++ b/qclib/state_preparation/merge.py
@@ -177,10 +177,6 @@ class MergeInitialize(InitializeSparse):
                 dif_values.append("1")
                 temp_strings = t_1
 
-            # dif_qubits must have at least two values stored in it
-            if (len(temp_strings) - 1) == 1 and len(dif_qubits) == 1:
-                temp_strings = b_strings
-
         return temp_strings, dif_qubits, dif_values
 
     def _select_strings(self, state_dict):

--- a/qclib/util.py
+++ b/qclib/util.py
@@ -266,7 +266,7 @@ def build_state_dict(state):
     Args:
       state: The classical description of the state vector
     """
-    n_qubits = np.ceil(np.log(len(state))).astype(int)
+    n_qubits = np.ceil(np.log2(len(state))).astype(int)
     state_dict = {}
     for (value_idx, value) in enumerate(state):
         if value != 0:

--- a/test/test_merge_initialize.py
+++ b/test/test_merge_initialize.py
@@ -21,6 +21,8 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qclib.state_preparation import MergeInitialize
 from qclib.util import get_state, build_state_dict
+from qiskit import transpile
+from scipy.sparse import random
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
@@ -71,3 +73,51 @@ class TestMergeInitialize(unittest.TestCase):
         circ = QuantumCircuit()
         with self.assertRaises(Exception): 
             initialize(circ, [])
+
+    def test_8qb_sparse(self):
+        state_dict = {
+            '01100000': 0.11496980229422502, 
+            '10010000': 0.2012068017595738,
+            '11110000': 0.2552406117427385,
+            '11001000': 0.24483730989689545,
+            '00011000': 0.08064396530053637, 
+            '01111000': 0.06609205232425505,
+            '10000100': 0.2567251902135311,
+            '00100010': 0.279179786457501,
+            '11110010': 0.14972323818181424,
+            '00000110': 0.054570286103576615,  
+            '10101110': 0.1953959409811345,
+            '00011110': 0.2476316976925628,
+            '00111110': 0.2460713287965397,
+            '00010001': 0.2880964575493704,
+            '00011001': 0.11697558413298771,  
+            '11100101': 0.15657582325155645,
+            '00101101': 0.05059343291713247,
+            '10011101': 0.21260965910383026,
+            '11100011': 0.16144719592639006,
+            '01110011': 0.24224885089395568,
+            '10011011': 0.07542653172823867,
+            '01111011': 0.2840232568261471, 
+            '00100111': 0.2719803407586484,
+            '01100111': 0.14940066988379283,  
+            '11010111': 0.2025293455684502, 
+            '01001111': 0.06045929196877916
+        }
+        initialize = MergeInitialize.initialize
+        qc = QuantumCircuit(8)
+        initialize(qc, state_dict)
+
+        t_circuit = transpile(qc, basis_gates=['cx', 'u'])
+
+    def test_several_qubit_sizes(self):
+        for n_qubits in range(4, 12):
+            state_vector = random(1, 2 ** n_qubits, density=0.1, random_state=42).A.reshape(-1)
+            state_vector = state_vector / np.linalg.norm(state_vector)
+            state_dict = build_state_dict(state_vector)
+
+            initialize = MergeInitialize.initialize
+            qc = QuantumCircuit(n_qubits)
+            initialize(qc, state_dict)
+
+            state = get_state(qc)
+            self.assertTrue(np.allclose(state_vector, state))


### PR DESCRIPTION
- When running the method Merge Initialize for sparse states the procedure would raise the following error:
```python
line 219, in _select_strings
    bitstr2 = b_strings1[0]
IndexError: list index out of range
```

This error was raised due to some residual code from an old version on method `_bit_string_search`. Formerly, lines `180-183`. 
```python
if (len(temp_strings) - 1) == 1 and len(dif_qubits) == 1:
                temp_strings = b_strings
```
This was done to make sure  either `temp_strings` or `dif_qubits` were not empty. However, in the current version this requirement is met by `_maximizing_difference_bit_search`

- New test cases have also been added to cover systems with more qubits
