### PR TITLE
Failing test_several_qubit_sizes unittest due to attribute absence

### DIFF
--- a/test/test_merge_initialize.py
+++ b/test/test_merge_initialize.py
@@ -111,7 +111,7 @@ class TestMergeInitialize(unittest.TestCase):
 
     def test_several_qubit_sizes(self):
         for n_qubits in range(4, 12):
-            state_vector = random(1, 2 ** n_qubits, density=0.1, random_state=42).A.reshape(-1)
+            state_vector = random(1, 2 ** n_qubits, density=0.1, random_state=42).toarray().reshape(-1)
             state_vector = state_vector / np.linalg.norm(state_vector)
             state_dict = build_state_dict(state_vector)
 


### PR DESCRIPTION
**Cause:** 
The unittest `test_several_qubit_sizes` in the file `test_merge_initialize.py` fails becase the method `random` imported from the module `scipy.sparse` returns an object called COO_Matrix. The COO_Matrix object no longer presents the attribute `A` in python's most recent versions. 

**How to replicate it**
Run the unittest `test_several_qubit_sizes` on python version `3.10`.

**Solution:**

I switched the `A`  attribute for the method `toarray`.