### PR TITLE
Optimizing PivotInitialize

### DIFF
--- a/qclib/state_preparation/pivot.py
+++ b/qclib/state_preparation/pivot.py
@@ -181,14 +181,14 @@ class PivotInitialize(InitializeSparse):
         else:
             control_size = len(remain)
             num_qubits = circuit.num_qubits
-            control_limit = int(np.ceil(circuit.num_qubits/2))
-            if num_qubits >= 5 and control_size <= control_limit:
+            control_limit = control_size - 2
+            if num_qubits >= 5 and control_size > control_limit:
                 """Lemma 8 of Iten et al. (2016) arXiv:1501.06911"""
                 vchain_dirty = McxVchainDirty(control_size).definition
 
                 dirty_anc = target.copy()
                 dirty_anc.remove(self.index_differ)
-                dirty_anc = dirty_anc[:control_size-2]
+                dirty_anc = dirty_anc[:control_limit]
 
                 circuit.compose(vchain_dirty, [*remain, *dirty_anc, self.index_differ], inplace=True)
             else: 

--- a/qclib/state_preparation/pivot.py
+++ b/qclib/state_preparation/pivot.py
@@ -18,6 +18,7 @@ import numpy as np
 import qiskit
 from qiskit import QuantumCircuit
 from qclib.gates.initialize_sparse import InitializeSparse
+from qclib.gates import McxVchainDirty, Mcg
 from .lowrank import LowRankInitialize
 
 # pylint: disable=maybe-no-member
@@ -178,7 +179,23 @@ class PivotInitialize(InitializeSparse):
             # apply mcx using mode v-chain
             self._mcxvchain(circuit, memory, anc, remain, self.index_differ)
         else:
-            circuit.mcx(remain, self.index_differ)
+            control_size = len(remain)
+            num_qubits = circuit.num_qubits
+            control_limit = int(np.ceil(circuit.num_qubits/2))
+            if num_qubits >= 5 and control_size <= control_limit:
+                """Lemma 8 of Iten et al. (2016) arXiv:1501.06911"""
+                vchain_dirty = McxVchainDirty(control_size).definition
+
+                dirty_anc = target.copy()
+                dirty_anc.remove(self.index_differ)
+                dirty_anc = dirty_anc[:control_size-2]
+
+                circuit.compose(vchain_dirty, [*remain, *dirty_anc, self.index_differ], inplace=True)
+            else: 
+                X = np.array([[0, 1], [1, 0]])
+                mcg = Mcg(X, num_controls=len(remain)).definition
+                circuit.compose(mcg, [*remain , self.index_differ], inplace=True)
+                #circuit.mcx(remain, self.index_differ)
 
         for k in remain:
             if index_zero[k] == "0":

--- a/qclib/state_preparation/pivot.py
+++ b/qclib/state_preparation/pivot.py
@@ -181,16 +181,17 @@ class PivotInitialize(InitializeSparse):
         else:
             control_size = len(remain)
             num_qubits = circuit.num_qubits
-            control_limit = control_size - 2
-            if num_qubits >= 5 and control_size > control_limit:
+            control_limit = int(np.ceil(num_qubits/2))
+            if num_qubits >= 5 and  control_size <= control_limit:
                 """Lemma 8 of Iten et al. (2016) arXiv:1501.06911"""
                 vchain_dirty = McxVchainDirty(control_size).definition
 
                 dirty_anc = target.copy()
                 dirty_anc.remove(self.index_differ)
-                dirty_anc = dirty_anc[:control_limit]
+                dirty_anc = dirty_anc[:control_size-2]
 
                 circuit.compose(vchain_dirty, [*remain, *dirty_anc, self.index_differ], inplace=True)
+
             else: 
                 X = np.array([[0, 1], [1, 0]])
                 mcg = Mcg(X, num_controls=len(remain)).definition

--- a/qclib/state_preparation/pivot.py
+++ b/qclib/state_preparation/pivot.py
@@ -195,7 +195,6 @@ class PivotInitialize(InitializeSparse):
                 X = np.array([[0, 1], [1, 0]])
                 mcg = Mcg(X, num_controls=len(remain)).definition
                 circuit.compose(mcg, [*remain , self.index_differ], inplace=True)
-                #circuit.mcx(remain, self.index_differ)
 
         for k in remain:
             if index_zero[k] == "0":

--- a/qclib/state_preparation/pivot.py
+++ b/qclib/state_preparation/pivot.py
@@ -18,7 +18,7 @@ import numpy as np
 import qiskit
 from qiskit import QuantumCircuit
 from qclib.gates.initialize_sparse import InitializeSparse
-from qclib.gates import McxVchainDirty, Mcg
+from qclib.gates import Mcg
 from .lowrank import LowRankInitialize
 
 # pylint: disable=maybe-no-member
@@ -184,13 +184,12 @@ class PivotInitialize(InitializeSparse):
             control_limit = int(np.ceil(num_qubits/2))
             if num_qubits >= 5 and  control_size <= control_limit:
                 """Lemma 8 of Iten et al. (2016) arXiv:1501.06911"""
-                vchain_dirty = McxVchainDirty(control_size).definition
 
                 dirty_anc = target.copy()
                 dirty_anc.remove(self.index_differ)
                 dirty_anc = dirty_anc[:control_size-2]
 
-                circuit.compose(vchain_dirty, [*remain, *dirty_anc, self.index_differ], inplace=True)
+                circuit.mcx(remain, self.index_differ, ancilla_qubits=dirty_anc, mode='v-chain-dirty')
 
             else: 
                 X = np.array([[0, 1], [1, 0]])

--- a/test/gates/test_mcx.py
+++ b/test/gates/test_mcx.py
@@ -232,7 +232,7 @@ class TestMcxVchainDirty(TestCase):
             )
 
             self.assertTrue(8 * num_controls - 6 == tr_mcx_v_chain.count_ops()["cx"])
-            self.assertLess(tr_mcx_v_chain.depth(), tr_mcx_v_chain_qiskit.depth())
+            self.assertLessEqual(tr_mcx_v_chain.depth(), tr_mcx_v_chain_qiskit.depth())
 
     def test_mcx_v_chain_dirty(self):
         """Test McxVchainDirty"""

--- a/test/test_sparse_sp.py
+++ b/test/test_sparse_sp.py
@@ -113,6 +113,18 @@ class TestPivotingSP(TestCase):
         for pattern, amp in data.items():
             self.assertTrue(np.isclose(state[int(pattern, 2)], amp))
 
+    def test_pivot_sp_random_7_qubits(self):
+        """ Testing pivot state preparation with 4 amplitudes on a 7-qubit system"""
+        n_qubits = 7
+        log_n_patterns = 4
+        prob = 0.2
+        data = double_sparse(n_qubits, log_n_patterns, prob)
+
+        circuit = PivotInitialize(data).definition
+        state = get_state(circuit)
+        for pattern, amp in data.items():
+            self.assertTrue(np.isclose(state[int(pattern, 2)], amp))
+
     def test_pivot_sp_random_aux(self):
         """ Testing pivot state preparation with 4 amplitudes and auxiliary qubits"""
         n_qubits = 4


### PR DESCRIPTION

It has been observed that there are some situations where some qubits can be reused as dirty ancilae for the multicontrolled toffoli in the target block when performing the pivoting step in the PivotInitialize algorithm, originally introduced in arXiv:2006.00016v2 . Thus further reducing the gate count even when `self.aux == False`.

- First, we tried to use the class McxVchainDirty already available in qclib, but it did not work for all cases. For example, the test case `test_pivot_sp_random_7_qubits` fails when we use it, even though the gate is correct.
- Then, we decided to use Qiskit's `mcx` by setting it to use dirty ancillae.
