### PR TITLE
Fix: Suppress subnormal amplitudes to preserve unitarity in state preparation

### DIFF
--- a/qclib/isometry.py
+++ b/qclib/isometry.py
@@ -287,7 +287,7 @@ def _unitary(iso, basis=0):  # Lemma2 of https://arxiv.org/abs/1501.06911
     iden = np.identity(2)
     iso_norm = np.linalg.norm(iso, axis=0)[0]
 
-    if iso_norm > 1e-10:
+    if iso_norm > 1e-14:
         psi = iso / iso_norm
 
         psi_dagger = np.conj(psi.T)

--- a/qclib/isometry.py
+++ b/qclib/isometry.py
@@ -287,7 +287,7 @@ def _unitary(iso, basis=0):  # Lemma2 of https://arxiv.org/abs/1501.06911
     iden = np.identity(2)
     iso_norm = np.linalg.norm(iso, axis=0)[0]
 
-    if iso_norm != 0.0:
+    if iso_norm > 1e-10:
         psi = iso / iso_norm
 
         psi_dagger = np.conj(psi.T)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="qclib",
-    version="0.1.12",
+    version="0.1.13",
     author="qclib team",
     author_email="ajsilva@cin.ufpe.br",
     description="A quantum computing library using qiskit",


### PR DESCRIPTION
This PR addresses a numerical stability issue in the isometry routine caused by **subnormal floating-point values**. Subnormal values (e.g., < 1e-308) are prone to underflow and may be silently truncated during matrix operations, leading to the construction of **non-unitary matrices**.

This fix ensures that all matrix decompositions and subsequent quantum circuit constructions are based on numerically stable inputs, preserving unitarity and preventing downstream failures.  
Resolves issue #206 (*Bug: Low Rank State Preparation issue for large input vectors*).