### PR TITLE
Fix typos and change funciton name

### DIFF
--- a/qclib/gates/ldmcsu.py
+++ b/qclib/gates/ldmcsu.py
@@ -205,7 +205,7 @@ class LdMcSpecialUnitary(Gate):
     Linear-depth Multicontrolled Special Unitary
     --------------------------------------------
 
-    Implements the gate decompostion of any gate in SU(2) with linear depth (Ld)
+    Implements the gate decomposition of any gate in SU(2) with linear depth (Ld)
     presented in Lemma 7.9 in Barenco et al., 1995 (arXiv:quant-ph/9503016)
     with optimizations from Theorem 5 of Iten et al., 2016 (arXiv:1501.06911)
     """
@@ -280,7 +280,7 @@ class LdMcSpecialUnitary(Gate):
         of Iten et al. 2016 (arXiv:1501.06911).
         Parameters
         ----------
-            a_gate, b_gate and c_gate expceted to be special unitary gates
+            a_gate, b_gate and c_gate expected to be special unitary gates
         """
 
         if len(self.control_qubits) < 3:
@@ -351,7 +351,7 @@ class LdMcSpecialUnitary(Gate):
         Linear-depth Multicontrolled Special Unitary
         --------------------------------------------
 
-        Implements the gate decompostion of any gate in SU(2) with linear depth (Ld)
+        Implements the gate decomposition of any gate in SU(2) with linear depth (Ld)
         presented in Lemma 7.9 in Barenco et al., 1995 (arXiv:quant-ph/9503016)
         with optimizations from Theorem 5 of Iten et al., 2016 (arXiv:1501.06911)
         """

--- a/qclib/gates/mcx.py
+++ b/qclib/gates/mcx.py
@@ -33,7 +33,7 @@ from qclib.gates.util import apply_ctrl_state
 class McxVchainDirty(Gate):
     """
     Implementation based on lemma 8 of Iten et al. (2016) arXiv:1501.06911.
-    Decomposition of a multicontrolled X gate with at least k <= ceil(n/2) ancilae
+    Decomposition of a multicontrolled X gate with at least k <= ceil(n/2) ancillae
     for n as the total number of qubits in the system. It also includes optimizations
     using approximated Toffoli gates up to a diagonal.
     """
@@ -216,7 +216,7 @@ class McxVchainDirty(Gate):
     ):
         """
         Implementation based on lemma 8 of Iten et al. (2016) arXiv:1501.06911.
-        Decomposition of a multicontrolled X gate with at least k <= ceil(n/2) ancilae
+        Decomposition of a multicontrolled X gate with at least k <= ceil(n/2) ancillae
         for n as the total number of qubits in the system. It also includes optimizations
         using approximated Toffoli gates up to a diagonal.
         """

--- a/qclib/gates/qdmcu.py
+++ b/qclib/gates/qdmcu.py
@@ -32,10 +32,10 @@ from .util import check_u2
 
 class Qdmcu(Gate):
     """
-    Quandratic Depth Multi-Controlled Unitary
+    Quadratic Depth Multi-Controlled Unitary
     -----------------------------------------
 
-    Implements gate decomposition of a munticontrolled operator in U(2) according to
+    Implements gate decomposition of a multicontrolled operator in U(2) according to
     Theorem 4 of Iten et al. (2016) arXiv:1501.06911.
     """
 
@@ -51,7 +51,7 @@ class Qdmcu(Gate):
         unitary    : numpy.ndarray 2 x 2 unitary matrix
         controls   : Either qiskit.QuantumRegister or list of qiskit.Qubit containing the
                     qubits to be used as control gates.
-        target     : qiskit.Qubit on wich the unitary operation is to be applied
+        target     : qiskit.Qubit on which the unitary operation is to be applied
         ctrl_state : String of binary digits describing the basis state used as control
         """
         check_u2(unitary)

--- a/qclib/state_preparation/merge.py
+++ b/qclib/state_preparation/merge.py
@@ -32,7 +32,7 @@ class MergeInitialize(InitializeSparse):
     def __init__(self, params, label=None):
         """
         Classical algorithm that creates a quantum circuit C that loads
-        a sparse quantum state, applying a sequence of operations maping
+        a sparse quantum state, applying a sequence of operations mapping
         the desired state |sigma> to |0>. And then inverting C to obtain
         the mapping of |0> to the desired state |sigma>.
         Args:
@@ -190,7 +190,7 @@ class MergeInitialize(InitializeSparse):
         bitstr2: Second binary string
         dif_qubit: Qubit index to be used as target for the merging operation
         dif_qubits: List of qubit indexes where bitstr1 and bitstr2 must be equal, because the
-                    correspondig qubits of those indexes are to be used as control for the
+                    corresponding qubits of those indexes are to be used as control for the
                     merging operation
         """
         # Initialization
@@ -250,7 +250,7 @@ class MergeInitialize(InitializeSparse):
         operation: Operation to be applied to the states, it must be ['x', 'cx', 'merge']
         qubit_indexes: Indexes of the qubits on the binary strings where the operations are to
                         be applied
-        merge_strings: Binary strings associated ot the states on the quantum processor
+        merge_strings: Binary strings associated to the states on the quantum processor
                         to be merge e.g.:['01001', '10110']
         Returns:
         A state_dict with the updated states

--- a/qclib/state_preparation/util/baa.py
+++ b/qclib/state_preparation/util/baa.py
@@ -467,7 +467,7 @@ def _search_best(nodes):
     max_saved_cnots_nodes = [
         node for node in nodes if node.total_saved_cnots == max_total_saved_cnots
     ]
-    # Nodes with the minimum depth (wich depends on the size of the node's largest subsystem).
+    # Nodes with the minimum depth (which depends on the size of the node's largest subsystem).
     # Shallower circuits with the same number of CNOTs means more parallelism.
     min_depth = _max_subsystem_size(min(max_saved_cnots_nodes, key=_max_subsystem_size))
     min_depth_nodes = [

--- a/qclib/state_preparation/util/tree_utils.py
+++ b/qclib/state_preparation/util/tree_utils.py
@@ -176,7 +176,7 @@ def subtree_level_index(root, tree):
     """
     :param root: subtree root node
     :param tree: a tree node
-    :return: the index of tree node repective to the subtree defined by root
+    :return: the index of tree node respective to the subtree defined by root
     """
     return tree.index - root.index * 2 ** (tree.level - root.level)
 
@@ -185,7 +185,7 @@ def subtree_level_leftmost(root, level):
     """
     :param root: subtree root node
     :param level: level to search for the leftmost node
-    :return: the leftmost tree node repective to the subtree defined by root
+    :return: the leftmost tree node respective to the subtree defined by root
     """
     left = root
     while left and left.level < level:
@@ -199,7 +199,7 @@ def subtree_level_nodes(tree, level, level_nodes):
     the first value of tree (subtree root).
     :param tree: current tree node, starts with subtree root node
     :param level: level to search for the nodes
-    :out param level_nodes: a list with the level tree nodes repective to the
+    :out param level_nodes: a list with the level tree nodes respective to the
                             subtree defined by root, ordered from left to right
     """
     if tree.level < level:

--- a/qclib/unitary.py
+++ b/qclib/unitary.py
@@ -69,7 +69,7 @@ def build_unitary(gate, decomposition="qsd", iso=0):
             circuit.compose(gate_left, qubits, inplace=True)
 
         # Middle circuit
-        # Last CZGate is ommited and absorved into the neighboring multiplexor.
+        # Last CZGate is omitted and absorbed into the neighboring multiplexor.
         ucry = multiplexor(RYGate, list(2 * theta), CZGate, False)
 
         circuit.compose(
@@ -330,7 +330,7 @@ def _build_qr_gate_sequence(gate, n_qubits):
             matrix_rotation[row_idx, col_idx] = b
             matrix_rotation[row_idx, row_idx] = -a
 
-            # applyting matrix_rotation to the unitary
+            # applying matrix_rotation to the unitary
             gate = matrix_rotation @ gate
             gate_sequence.append(matrix_rotation.conj().T)
 

--- a/qclib/util.py
+++ b/qclib/util.py
@@ -129,7 +129,7 @@ def replace_all_values_with(new_value, dataset):
         and b is the binary pattern associated to it.
         this procedure performs the task of replacing
         v with the new_value
-    :param new_value: Value to replate the v in all the tuples
+    :param new_value: Value to replace the v in all the tuples
                       (v, b)
     :param dataset: List of tuples where the values are to be
                     replaced
@@ -143,9 +143,9 @@ def replace_all_values_with(new_value, dataset):
     return new_dataset
 
 
-def build_list_of_quibit_objects(quantum_register):
+def build_list_of_qubit_objects(quantum_register):
     """
-        Buid a list of Qubit objects to be used as
+        Build a list of Qubit objects to be used as
         input to some procedure of the qiskit framework
     :param quantum_register: Quantum register with the qubits
     :return: Qubits list
@@ -181,7 +181,7 @@ def verify_interval_in_state_vector(statevector, start, finish):
 def verify_trigonometric_interval(value):
     """
         Verify if a certain value is inside the interval
-        of the domain of the tirgonometric functions
+        of the domain of the trigonometric functions
         cosine and sine, [-1, 1]
     :param value: Real value to be evaluated
     :return: Value, if the value is inside the domain

--- a/test/gates/test_mcx.py
+++ b/test/gates/test_mcx.py
@@ -35,7 +35,7 @@ def apply_control_state_on_quantum_circuit(
     ----------
         quantum_circuit : QuantumCircuit object on which the X gates are to be applied
         control_bits    : QuantumRegister containing with the qubits to be used as control
-        ctrl_state  : String of binary digits describing wich state is used as control
+        ctrl_state  : String of binary digits describing which state is used as control
                     in the multicontrolled operation
     """
     if ctrl_state is not None:


### PR DESCRIPTION
### Fix typos
- decompostion -> decomposition
- expceted -> expected
- ancilae -> ancillae
- Quandratic -> Quadratic
- munticontrolled -> multicontrolled
- wich -> which
- maping -> mapping
- correspondig -> corresponding
- associated ot -> associated to
- repective -> respective
- ommited -> omitted
- absorved -> absorbed
- applyting -> applying
- replate -> replace
- Change function name from `build_list_of_quibit_objects` to `build_list_of_qubit_objects`
- Buid -> Build
- tirgonometric -> trigonometric